### PR TITLE
Add task service tests

### DIFF
--- a/planner_bot/database/models.py
+++ b/planner_bot/database/models.py
@@ -27,3 +27,63 @@ class Reminder(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     project = relationship("Project", back_populates="reminders")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(255), nullable=False)
+    description = Column(Text)
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    user_id = Column(Integer, nullable=False)
+    deadline = Column(DateTime)
+    estimate_hours = Column(Integer)
+    priority = Column(String(50))
+    status = Column(String(50))
+    parent_id = Column(Integer, ForeignKey("tasks.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    project = relationship("Project")
+    parent = relationship("Task", remote_side=[id])
+    links = relationship(
+        "TaskLink",
+        back_populates="task",
+        cascade="all, delete-orphan",
+        foreign_keys="TaskLink.task_id",
+    )
+    results = relationship(
+        "TaskResult",
+        back_populates="task",
+        cascade="all, delete-orphan",
+    )
+
+
+class TaskLink(Base):
+    __tablename__ = "task_links"
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    related_task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    type = Column(String(50), nullable=False)
+
+    task = relationship("Task", foreign_keys=[task_id], back_populates="links")
+    related_task = relationship("Task", foreign_keys=[related_task_id])
+
+
+class TaskResult(Base):
+    __tablename__ = "task_results"
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    user_id = Column(Integer, nullable=False)
+    result = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+    )
+
+    task = relationship("Task", back_populates="results")

--- a/planner_bot/database/schemas.py
+++ b/planner_bot/database/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from datetime import datetime
 from typing import Optional
 
@@ -10,8 +10,7 @@ class ProjectSchema(BaseModel):
     created_at: datetime
     updated_at: Optional[datetime]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class ReminderSchema(BaseModel):
     id: int
@@ -22,5 +21,41 @@ class ReminderSchema(BaseModel):
     created_at: datetime
     project: Optional[ProjectSchema] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskSchema(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    project_id: Optional[int] = None
+    user_id: int
+    deadline: Optional[datetime] = None
+    estimate_hours: Optional[int] = None
+    priority: Optional[str] = None
+    status: Optional[str] = None
+    parent_id: Optional[int] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskLinkSchema(BaseModel):
+    id: int
+    task_id: int
+    related_task_id: int
+    type: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskResultSchema(BaseModel):
+    id: int
+    task_id: int
+    user_id: int
+    result: str
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/planner_bot/llm/__init__.py
+++ b/planner_bot/llm/__init__.py
@@ -1,0 +1,4 @@
+from .client import ask
+from .tools import task_tools
+
+__all__ = ["ask", "task_tools"]

--- a/planner_bot/llm/tools.py
+++ b/planner_bot/llm/tools.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+
+try:
+    from langchain.tools import tool
+except Exception:  # pragma: no cover - fallback for new versions
+    from langchain_core.tools import tool
+
+from ..database.session import async_session_factory
+from ..services.tasks import (
+    create_task,
+    list_tasks,
+    update_task,
+    delete_task,
+    add_task_result,
+    list_task_results,
+)
+
+
+@tool("create_task")
+async def create_task_tool(
+    user_id: int,
+    title: str,
+    description: str | None = None,
+    project_id: int | None = None,
+    deadline: str | None = None,
+    estimate_hours: int | None = None,
+    priority: str | None = None,
+    status: str | None = None,
+    parent_id: int | None = None,
+) -> dict:
+    """Create a task for a user."""
+    _deadline = datetime.fromisoformat(deadline) if deadline else None
+    async with async_session_factory() as session:
+        task = await create_task(
+            session,
+            user_id=user_id,
+            title=title,
+            description=description,
+            project_id=project_id,
+            deadline=_deadline,
+            estimate_hours=estimate_hours,
+            priority=priority,
+            status=status,
+            parent_id=parent_id,
+        )
+        return task.dict()
+
+
+@tool("list_tasks")
+async def list_tasks_tool(user_id: int) -> list[dict]:
+    """List tasks for the given user."""
+    async with async_session_factory() as session:
+        tasks = await list_tasks(session, user_id)
+        return [t.dict() for t in tasks]
+
+
+@tool("update_task")
+async def update_task_tool(
+    user_id: int,
+    task_id: int,
+    title: str | None = None,
+    description: str | None = None,
+    project_id: int | None = None,
+    deadline: str | None = None,
+    estimate_hours: int | None = None,
+    priority: str | None = None,
+    status: str | None = None,
+    parent_id: int | None = None,
+) -> dict | None:
+    """Update a task and return the new values."""
+    fields = {}
+    if title is not None:
+        fields["title"] = title
+    if description is not None:
+        fields["description"] = description
+    if project_id is not None:
+        fields["project_id"] = project_id
+    if deadline is not None:
+        fields["deadline"] = datetime.fromisoformat(deadline)
+    if estimate_hours is not None:
+        fields["estimate_hours"] = estimate_hours
+    if priority is not None:
+        fields["priority"] = priority
+    if status is not None:
+        fields["status"] = status
+    if parent_id is not None:
+        fields["parent_id"] = parent_id
+    async with async_session_factory() as session:
+        task = await update_task(session, task_id, user_id, **fields)
+        return task.dict() if task else None
+
+
+@tool("delete_task")
+async def delete_task_tool(user_id: int, task_id: int) -> str:
+    """Delete a task."""
+    async with async_session_factory() as session:
+        await delete_task(session, task_id, user_id)
+    return "deleted"
+
+
+@tool("add_task_result")
+async def add_task_result_tool(task_id: int, user_id: int, result: str) -> dict:
+    """Attach a result text to a task."""
+    async with async_session_factory() as session:
+        res = await add_task_result(session, task_id, user_id, result)
+        return res.dict()
+
+
+@tool("list_task_results")
+async def list_task_results_tool(task_id: int) -> list[dict]:
+    """Return all results for a task."""
+    async with async_session_factory() as session:
+        results = await list_task_results(session, task_id)
+        return [r.dict() for r in results]
+
+
+task_tools = [
+    create_task_tool,
+    list_tasks_tool,
+    update_task_tool,
+    delete_task_tool,
+    add_task_result_tool,
+    list_task_results_tool,
+]

--- a/planner_bot/services/__init__.py
+++ b/planner_bot/services/__init__.py
@@ -1,0 +1,7 @@
+from . import projects, reminders, tasks
+
+__all__ = [
+    "projects",
+    "reminders",
+    "tasks",
+]

--- a/planner_bot/services/projects.py
+++ b/planner_bot/services/projects.py
@@ -8,12 +8,12 @@ async def create_project(session: AsyncSession, user_id: int, title: str, descri
     session.add(project)
     await session.commit()
     await session.refresh(project)
-    return ProjectSchema.from_orm(project)
+    return ProjectSchema.model_validate(project)
 
 async def list_projects(session: AsyncSession, user_id: int) -> list[ProjectSchema]:
     result = await session.execute(select(Project).where(Project.user_id == user_id))
     projects = result.scalars().all()
-    return [ProjectSchema.from_orm(p) for p in projects]
+    return [ProjectSchema.model_validate(p) for p in projects]
 
 async def delete_project(session: AsyncSession, project_id: int, user_id: int) -> None:
     await session.execute(delete(Project).where(Project.id == project_id, Project.user_id == user_id))

--- a/planner_bot/services/reminders.py
+++ b/planner_bot/services/reminders.py
@@ -10,12 +10,12 @@ async def create_reminder(session: AsyncSession, project_id: int, description: s
     session.add(reminder)
     await session.commit()
     await session.refresh(reminder)
-    return ReminderSchema.from_orm(reminder)
+    return ReminderSchema.model_validate(reminder)
 
 async def list_reminders(session: AsyncSession, project_id: int) -> list[ReminderSchema]:
     result = await session.execute(select(Reminder).where(Reminder.project_id == project_id))
     reminders = result.scalars().all()
-    return [ReminderSchema.from_orm(r) for r in reminders]
+    return [ReminderSchema.model_validate(r) for r in reminders]
 
 async def delete_reminder(session: AsyncSession, reminder_id: int) -> None:
     await session.execute(delete(Reminder).where(Reminder.id == reminder_id))
@@ -25,4 +25,4 @@ async def due_reminders(session: AsyncSession, now: datetime) -> list[ReminderSc
     stmt = select(Reminder).where(Reminder.remind_at <= now).options(selectinload(Reminder.project))
     result = await session.execute(stmt)
     reminders = result.scalars().all()
-    return [ReminderSchema.from_orm(r) for r in reminders]
+    return [ReminderSchema.model_validate(r) for r in reminders]

--- a/planner_bot/services/tasks.py
+++ b/planner_bot/services/tasks.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Any
+from sqlalchemy import select, delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from ..database.models import Task, TaskLink, TaskResult
+from ..database.schemas import TaskSchema, TaskLinkSchema, TaskResultSchema
+
+async def create_task(
+    session: AsyncSession,
+    user_id: int,
+    title: str,
+    description: str | None = None,
+    project_id: int | None = None,
+    deadline: datetime | None = None,
+    estimate_hours: int | None = None,
+    priority: str | None = None,
+    status: str | None = None,
+    parent_id: int | None = None,
+) -> TaskSchema:
+    task = Task(
+        title=title,
+        description=description,
+        project_id=project_id,
+        user_id=user_id,
+        deadline=deadline,
+        estimate_hours=estimate_hours,
+        priority=priority,
+        status=status,
+        parent_id=parent_id,
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(task)
+    return TaskSchema.model_validate(task)
+
+async def list_tasks(session: AsyncSession, user_id: int) -> list[TaskSchema]:
+    result = await session.execute(select(Task).where(Task.user_id == user_id))
+    tasks = result.scalars().all()
+    return [TaskSchema.model_validate(t) for t in tasks]
+
+async def update_task(session: AsyncSession, task_id: int, user_id: int, **fields: Any) -> TaskSchema | None:
+    await session.execute(
+        update(Task).where(Task.id == task_id, Task.user_id == user_id).values(**fields)
+    )
+    await session.commit()
+    result = await session.execute(select(Task).where(Task.id == task_id, Task.user_id == user_id))
+    task = result.scalar_one_or_none()
+    return TaskSchema.model_validate(task) if task else None
+
+async def delete_task(session: AsyncSession, task_id: int, user_id: int) -> None:
+    await session.execute(delete(Task).where(Task.id == task_id, Task.user_id == user_id))
+    await session.commit()
+
+async def add_task_link(session: AsyncSession, task_id: int, related_task_id: int, link_type: str) -> TaskLinkSchema:
+    link = TaskLink(task_id=task_id, related_task_id=related_task_id, type=link_type)
+    session.add(link)
+    await session.commit()
+    await session.refresh(link)
+    return TaskLinkSchema.model_validate(link)
+
+async def list_task_links(session: AsyncSession, task_id: int) -> list[TaskLinkSchema]:
+    result = await session.execute(select(TaskLink).where(TaskLink.task_id == task_id))
+    links = result.scalars().all()
+    return [TaskLinkSchema.model_validate(l) for l in links]
+
+
+async def add_task_result(
+    session: AsyncSession,
+    task_id: int,
+    user_id: int,
+    result_text: str,
+) -> TaskResultSchema:
+    result = TaskResult(task_id=task_id, user_id=user_id, result=result_text)
+    session.add(result)
+    await session.commit()
+    await session.refresh(result)
+    return TaskResultSchema.model_validate(result)
+
+
+async def list_task_results(session: AsyncSession, task_id: int) -> list[TaskResultSchema]:
+    res = await session.execute(select(TaskResult).where(TaskResult.task_id == task_id))
+    results = res.scalars().all()
+    return [TaskResultSchema.model_validate(r) for r in results]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pathlib
+import asyncio
+import pytest
+import pytest_asyncio
+
+# Setup environment variables for config
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("DATABASE_DSN", "sqlite+aiosqlite:///./test.db")
+
+# ensure project root on path
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from planner_bot.database.session import async_session_factory, init_db
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def setup_db():
+    await init_db()
+    yield
+    if os.path.exists("./test.db"):
+        os.remove("./test.db")
+
+@pytest_asyncio.fixture()
+async def session():
+    async with async_session_factory() as s:
+        yield s
+        await s.rollback()

--- a/tests/test_tasks_service.py
+++ b/tests/test_tasks_service.py
@@ -1,0 +1,44 @@
+import pytest
+from datetime import datetime
+
+from planner_bot.services.tasks import (
+    create_task,
+    list_tasks,
+    update_task,
+    delete_task,
+    add_task_link,
+    list_task_links,
+    add_task_result,
+    list_task_results,
+)
+
+
+@pytest.mark.asyncio
+async def test_task_crud(session):
+    task = await create_task(session, user_id=1, title="t1")
+    assert task.id is not None
+    assert task.title == "t1"
+
+    tasks = await list_tasks(session, user_id=1)
+    assert len(tasks) == 1
+
+    updated = await update_task(session, task.id, 1, title="new")
+    assert updated.title == "new"
+
+    await delete_task(session, task.id, 1)
+    tasks = await list_tasks(session, user_id=1)
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_task_links_and_results(session):
+    t1 = await create_task(session, user_id=1, title="t1")
+    t2 = await create_task(session, user_id=1, title="t2")
+
+    link = await add_task_link(session, t1.id, t2.id, "related")
+    links = await list_task_links(session, t1.id)
+    assert links == [link]
+
+    res = await add_task_result(session, t1.id, 1, "done")
+    results = await list_task_results(session, t1.id)
+    assert results == [res]


### PR DESCRIPTION
## Summary
- add pytest fixtures for DB setup
- implement async task service tests
- update Pydantic schemas and service functions to use `model_validate`
- specify `foreign_keys` on Task.links

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a56b08e3083278aeedf5121f6e5f8